### PR TITLE
chore: add Vite cache and coverage directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ node_modules
 # builds
 dist
 
+# Vite
+.vite
+coverage
+
 # env
 .env*
 !.env.example


### PR DESCRIPTION
## Description

This PR updates the  file to exclude Vite build cache and test coverage directories.

## Changes Made

- Add  directory (Vite build cache)
- Add  directory (test coverage reports)
- Prevents committing build artifacts and cache files

## Why This Is Needed

- ****: Vite creates this directory during development for caching dependencies and build artifacts
- ****: Generated by test coverage tools and should not be committed
- **Clean repository**: Prevents accidentally committing large cache files and build artifacts

## Testing

- ✅  directory will be ignored by git
- ✅  directory will be ignored by git
- ✅ No impact on existing functionality