### PR TITLE
fix: Implement Option B test flow redesign for optimistic concurrency (fixes #42)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default [
         localStorage: 'readonly',
         console: 'readonly',
         process: 'readonly',
+        fetch: 'readonly',
       },
     },
     plugins: {

--- a/mock-api-server.cjs
+++ b/mock-api-server.cjs
@@ -98,6 +98,40 @@ app.get('/components/:id', (req, res) => {
   }
 });
 
+// Project-specific component list endpoint
+app.get('/projects/:projectId/components', (req, res) => {
+  const projectComponents = components.filter(
+    c => c.projectId === req.params.projectId
+  );
+  res.json({
+    components: projectComponents,
+    total: projectComponents.length,
+    limit: parseInt(req.query.limit) || 10,
+    offset: parseInt(req.query.offset) || 0,
+  });
+});
+
+// Project-specific component creation endpoint
+app.post('/projects/:projectId/components', (req, res) => {
+  const component = {
+    id: `component-${nextId++}`,
+    projectId: req.params.projectId,
+    name: req.body.name,
+    description: req.body.description || '',
+    type: req.body.type || 'api',
+    status: req.body.status || 'active',
+    config: req.body.config || {},
+    metadata: req.body.metadata || {},
+    fields: req.body.fields || [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  components.push(component);
+  console.log('Created component:', component);
+  console.log('Total components:', components.length);
+  res.json(component);
+});
+
 // Project-specific component endpoint
 app.get('/projects/:projectId/components/:id', (req, res) => {
   console.log(

--- a/mock-api-server.cjs
+++ b/mock-api-server.cjs
@@ -103,11 +103,14 @@ app.get('/projects/:projectId/components', (req, res) => {
   const projectComponents = components.filter(
     c => c.projectId === req.params.projectId
   );
+  const limit = parseInt(req.query.limit) || 10;
+  const offset = parseInt(req.query.offset) || 0;
+  const paginatedComponents = projectComponents.slice(offset, offset + limit);
   res.json({
-    components: projectComponents,
+    components: paginatedComponents,
     total: projectComponents.length,
-    limit: parseInt(req.query.limit) || 10,
-    offset: parseInt(req.query.offset) || 0,
+    limit,
+    offset,
   });
 });
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -48,6 +48,7 @@ export default function Toast({
 
   return (
     <div
+      data-testid={type === 'success' ? 'toast-success' : 'toast-error'}
       className={`fixed top-4 right-4 z-50 max-w-sm w-full bg-white border rounded-lg shadow-lg transform transition-all duration-300 ${
         isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'
       } ${bgColor} ${borderColor}`}

--- a/src/features/components/ComponentDesigner.tsx
+++ b/src/features/components/ComponentDesigner.tsx
@@ -463,6 +463,7 @@ fields: []`;
                     {...register('name')}
                     type="text"
                     id="name"
+                    data-testid="component-name"
                     className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
                     placeholder="Component name"
                   />

--- a/src/features/components/ConflictResolutionModal.tsx
+++ b/src/features/components/ConflictResolutionModal.tsx
@@ -23,7 +23,10 @@ export default function ConflictResolutionModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      data-testid="conflict-resolution-modal"
+    >
       <div className="bg-background border border-border rounded-lg p-6 max-w-2xl w-full mx-4">
         <div className="mb-4">
           <h2 className="text-xl font-semibold text-foreground mb-2">

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -30,14 +30,22 @@ export async function getComponentWithETag(
   const baseUrl =
     import.meta.env?.VITE_API_BASE_URL || 'https://api.auren.dev/v0';
   const url = `${baseUrl}/projects/${projectId}/components/${componentId}`;
-  const headers = authHeader();
+  const authHeaders = authHeader();
+
+  // Construct headers object explicitly to satisfy TypeScript
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if ('Authorization' in authHeaders) {
+    const authValue = authHeaders.Authorization;
+    if (authValue) {
+      headers.Authorization = authValue;
+    }
+  }
 
   const response = await fetch(url, {
     method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-    },
+    headers,
   });
 
   if (!response.ok) {

--- a/tests/e2e/edit-component-concurrency.spec.ts
+++ b/tests/e2e/edit-component-concurrency.spec.ts
@@ -100,13 +100,16 @@ test('optimistic concurrency: second editor sees conflict and reloads latest', a
   // Verify the response was successful
   expect(response.status()).toBe(200);
 
-  // Wait for the success toast to appear (toast appears before navigation)
-  await expect(
-    p1.locator(
-      '[data-testid="toast-success"]:has-text("Component updated successfully!")'
-    )
-  ).toBeVisible({
+  // Wait for the success toast to appear (toast appears after mutation succeeds)
+  // The mutation's onSuccess callback shows the toast, which may happen after the response
+  // First wait for any success toast to appear
+  const toast = p1.locator('[data-testid="toast-success"]');
+  await expect(toast).toBeVisible({
     timeout: 5000,
+  });
+  // Then verify it contains the expected message
+  await expect(toast).toContainText('Component updated successfully!', {
+    timeout: 2000,
   });
 
   // 4. Second editor tries to save (should conflict)

--- a/tests/e2e/edit-component-concurrency.spec.ts
+++ b/tests/e2e/edit-component-concurrency.spec.ts
@@ -1,0 +1,129 @@
+import { test, request, expect } from '@playwright/test';
+
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:3000';
+const STUDIO_BASE_URL = process.env.STUDIO_BASE_URL || 'http://localhost:5173';
+
+async function devLogin(api: any) {
+  const r = await api.post(`${API_BASE}/auth/login`, {
+    data: { email: 'dev@auren.local', role: 'OWNER' },
+  });
+  const body = await r.json();
+  return body.token || body.jwt || body.accessToken;
+}
+
+async function createProject(api: any, token: string) {
+  const r = await api.post(`${API_BASE}/projects`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name: 'E2E Concurrency Test Project', ownerId: 'dev-owner' },
+  });
+  const j = await r.json();
+  return j.id;
+}
+
+async function createComponent(api: any, token: string, projectId: string) {
+  const r = await api.post(`${API_BASE}/projects/${projectId}/components`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      name: 'Test Component',
+      type: 'api',
+      status: 'active',
+      fields: [
+        { key: 'title', type: 'text', label: 'Title', required: true },
+        { key: 'amount', type: 'number', label: 'Amount' },
+      ],
+    },
+  });
+  const j = await r.json();
+  return j.id;
+}
+
+test('optimistic concurrency: second editor sees conflict and reloads latest', async ({
+  browser,
+}) => {
+  // Setup: Create project and component
+  const api = await request.newContext();
+  const token = await devLogin(api);
+  const projectId = await createProject(api, token);
+  const componentId = await createComponent(api, token, projectId);
+
+  // 1. Both editors load the same component simultaneously
+  const p1 = await browser.newPage();
+  const p2 = await browser.newPage();
+
+  // Set auth token in both pages
+  await p1.addInitScript(token => {
+    localStorage.setItem('auth_token', token);
+  }, token);
+  await p2.addInitScript(token => {
+    localStorage.setItem('auth_token', token);
+  }, token);
+
+  // Navigate both pages to the component editor
+  await p1.goto(
+    `${STUDIO_BASE_URL}/projects/${projectId}/components/${componentId}`
+  );
+  await p2.goto(
+    `${STUDIO_BASE_URL}/projects/${projectId}/components/${componentId}`
+  );
+
+  // Wait for both pages to load
+  await p1.waitForLoadState('networkidle');
+  await p2.waitForLoadState('networkidle');
+
+  // Wait for the component designer to be visible and form to be ready
+  await p1.waitForSelector('h2:has-text("Edit Component")');
+  await p2.waitForSelector('h2:has-text("Edit Component")');
+
+  // Wait for the component name input to be visible and ready
+  await p1.waitForSelector('[data-testid="component-name"]');
+  await p2.waitForSelector('[data-testid="component-name"]');
+
+  // 2. Both editors make changes to their local state
+  // Editor 1 changes the name
+  await p1.fill('[data-testid="component-name"]', 'Updated by Editor 1');
+  // Editor 2 changes the name
+  await p2.fill('[data-testid="component-name"]', 'Updated by Editor 2');
+
+  // 3. First editor saves successfully (updates server ETag)
+  await p1.click('button[type="submit"]');
+  await p1.waitForLoadState('networkidle');
+
+  // Verify first editor's save was successful
+  await expect(p1.locator('text=Component updated successfully')).toBeVisible({
+    timeout: 5000,
+  });
+
+  // 4. Second editor tries to save (should conflict)
+  await p2.click('button[type="submit"]');
+  await p2.waitForLoadState('networkidle');
+
+  // 5. Verify conflict resolution modal appears
+  await expect(
+    p2.locator('[data-testid="conflict-resolution-modal"]')
+  ).toBeVisible({ timeout: 5000 });
+
+  // Verify modal content
+  await expect(p2.locator('text=Conflict Detected')).toBeVisible();
+  await expect(p2.locator('text=Latest Version')).toBeVisible();
+  await expect(p2.locator('text=Your Draft')).toBeVisible();
+
+  // 6. Click "Open Latest Version" button
+  await p2.click('button:has-text("Open Latest Version")');
+
+  // Wait for the modal to close and form to update
+  await p2.waitForSelector('[data-testid="conflict-resolution-modal"]', {
+    state: 'hidden',
+  });
+  await p2.waitForLoadState('networkidle');
+
+  // Verify that the latest version was loaded
+  // The component name should now be "Updated by Editor 1"
+  await expect(p2.locator('[data-testid="component-name"]')).toHaveValue(
+    'Updated by Editor 1',
+    { timeout: 5000 }
+  );
+
+  // Cleanup
+  await p1.close();
+  await p2.close();
+});

--- a/tests/e2e/edit-component-concurrency.spec.ts
+++ b/tests/e2e/edit-component-concurrency.spec.ts
@@ -100,14 +100,16 @@ test('optimistic concurrency: second editor sees conflict and reloads latest', a
   // Verify the response was successful
   expect(response.status()).toBe(200);
 
+  // Wait for network to be idle to ensure React Query has processed the mutation
+  await p1.waitForLoadState('networkidle');
+  
   // Wait for the success toast to appear (toast appears after mutation succeeds)
   // The mutation's onSuccess callback shows the toast, which may happen after the response
-  // First wait for any success toast to appear
   const toast = p1.locator('[data-testid="toast-success"]');
   await expect(toast).toBeVisible({
     timeout: 5000,
   });
-  // Then verify it contains the expected message
+  // Verify it contains the expected message
   await expect(toast).toContainText('Component updated successfully!', {
     timeout: 2000,
   });

--- a/tests/e2e/edit-component-concurrency.spec.ts
+++ b/tests/e2e/edit-component-concurrency.spec.ts
@@ -85,11 +85,20 @@ test('optimistic concurrency: second editor sees conflict and reloads latest', a
   await p2.fill('[data-testid="component-name"]', 'Updated by Editor 2');
 
   // 3. First editor saves successfully (updates server ETag)
-  await p1.click('button[type="submit"]');
+  const submitButton1 = p1.locator('button[type="submit"]');
+  await submitButton1.click();
+
+  // Wait for the button to not be disabled (mutation completed)
+  await expect(submitButton1).not.toBeDisabled({ timeout: 5000 });
   await p1.waitForLoadState('networkidle');
 
   // Verify first editor's save was successful
-  await expect(p1.locator('text=Component updated successfully')).toBeVisible({
+  // Wait for the success toast to appear
+  await expect(
+    p1.locator(
+      '[data-testid="toast-success"]:has-text("Component updated successfully!")'
+    )
+  ).toBeVisible({
     timeout: 5000,
   });
 

--- a/tests/e2e/edit-component-concurrency.spec.ts
+++ b/tests/e2e/edit-component-concurrency.spec.ts
@@ -102,7 +102,7 @@ test('optimistic concurrency: second editor sees conflict and reloads latest', a
 
   // Wait for network to be idle to ensure React Query has processed the mutation
   await p1.waitForLoadState('networkidle');
-  
+
   // Wait for the success toast to appear (toast appears after mutation succeeds)
   // The mutation's onSuccess callback shows the toast, which may happen after the response
   const toast = p1.locator('[data-testid="toast-success"]');

--- a/tests/e2e/edit-component-concurrency.spec.ts
+++ b/tests/e2e/edit-component-concurrency.spec.ts
@@ -126,4 +126,5 @@ test('optimistic concurrency: second editor sees conflict and reloads latest', a
   // Cleanup
   await p1.close();
   await p2.close();
+  await api.dispose();
 });


### PR DESCRIPTION
## Summary
This PR implements Option B from issue #42: redesigning the E2E test flow to prevent automatic data updates and properly test optimistic concurrency conflict resolution.

## Changes
- ✅ Redesigned test flow: both editors load component, make changes, then save sequentially
- ✅ Added test data attributes (`data-testid`) for reliable element selection
- ✅ Added project-specific component endpoints to mock API server
- ✅ Implemented complete E2E test that verifies conflict detection and resolution

## Test Flow
1. Both editors load the same component simultaneously
2. Both editors make changes to their local state
3. First editor saves successfully (updates server ETag)
4. Second editor tries to save with stale ETag → triggers 409 conflict
5. Conflict resolution modal appears with "Open Latest Version" button
6. Second editor reloads latest version successfully

## Related Issues
- Fixes #42 (Option B: Redesign test flow to prevent automatic data updates)
- Closes #41 (Option A: Mock network responses - no longer needed)
- Closes #43 (Option C: Disable React Query cache invalidation - no longer needed)

## Acceptance Criteria Met
- [x] Both editors load the same component
- [x] Both editors can make changes independently
- [x] First editor saves successfully
- [x] Second editor encounters 409 conflict when saving
- [x] Conflict resolution modal appears with "Open Latest Version" button
- [x] Test passes consistently